### PR TITLE
require application to supply library context

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ HASHMLDSA *hashmldsa_data = NULL;
 char *signature = NULL;
 size_t signature_len = 0;
 EVP_PKEY *private_key = NULL; // to contain the private key
+OSSL_LIB_CTX *lib_ctx;        // openssl library context (to be populated by app)
 int rc = SUCCESS;             // developer defined return code
 ...
-hashmldsa_ctx = HASHMLDSA_CTX_new("ML-DSA-44");
+hashmldsa_ctx = HASHMLDSA_CTX_new(lib_ctx, "ML-DSA-44");
 if (hashmldsa_ctx == NULL) {
     HASHMLDSA_print_last_error(stderr);
     rc = FAILURE;
@@ -96,9 +97,10 @@ size_t hashed_message_len = 0;        // to contain the length the the hashed me
 unsigned char* signature = NULL;      // to contain the signature
 size_t signature_len = 0;             // to contain the signature length
 EVP_PKEY *public_key = NULL;          // to contain the public key
+OSSL_LIB_CTX *lib_ctx;                // openssl library context (to be populated by app)
 int rc = SUCCESS;                     // developer defined return code
 ...
-hashmldsa_ctx = HASHMLDSA_CTX_new("MLDSA65"); // note the different format of the signature algorithm is also supported
+hashmldsa_ctx = HASHMLDSA_CTX_new((lib_ctx, "MLDSA65"); // note the different format of the signature algorithm is also supported
 if (hashmldsa_ctx == NULL) {
     HASHMLDSA_print_last_error(stderr);
     rc = FAILURE;
@@ -137,9 +139,10 @@ HASHMLDSA_CTX *hashmldsa_ctx = NULL;
 HASHMLDSA *hashmldsa_data = NULL;
 unsigned char* hashed_message = NULL;
 size_t hashed_message_len = 0;
+OSSL_LIB_CTX *lib_ctx; // openssl library context (to be populated by app)
 int rc = SUCCESS;      // developer defined return code
 ...
-hashmldsa_ctx = HASHMLDSA_CTX_new("ML-DSA-44");  // signature algorithm may seem unnecessary, but means we can use context for other operations
+hashmldsa_ctx = HASHMLDSA_CTX_new((lib_ctx, "ML-DSA-44");  // signature algorithm may seem unnecessary, but means we can use context for other operations
 if (hashmldsa_ctx == NULL) {
     HASHMLDSA_print_last_error(stderr);
     rc = FAILURE;

--- a/api_documentation.md
+++ b/api_documentation.md
@@ -1,7 +1,7 @@
 # API Documentation
 
 ```c
-HASHMLDSA_CTX *HASHMLDSA_CTX_new(const char *sig_alg_name)
+HASHMLDSA_CTX *HASHMLDSA_CTX_new(OSSL_LIB_CTX *lib_ctx, const char *sig_alg_name)
 ```
 
 **Description**:
@@ -9,6 +9,7 @@ Allocates memory for a new HASHMLDSA context structure and initializes its field
 
 **Parameters**:
 
+- *lib_ctx*: An openssl Library context. NULL is not valid. If this library context doesn't have the default provider loaded, it will be loaded into this context.
 - *sig_alg_name*: The required signature algorithm.
 
 **Returns**:
@@ -17,11 +18,16 @@ A pointer to the newly created HASHMLDSA context on success, NULL on failure.
 ---
 
 ```c
-HASHMLDSA_CTX *HASHMLDSA_CTX_new_for_test(const char* sig_alg_name)
+HASHMLDSA_CTX *HASHMLDSA_CTX_new_for_test(OSSL_LIB_CTX *lib_ctx, const char* sig_alg_name)
 ```
 
 **Description**:
 Allocates memory for a new HASHMLDSA context structure and initializes its fields. The only supported algorithms are ML-DSA-44, ML-DSA-65 or ML-DSA-87. Alternative names such as MLDSA44 are also allowed. It returns a pointer to the newly created context or NULL if memory allocation fails. This will force deterministic mode for signing and should only be used for testing purposes. A default digest will be assigned to this context which will have the necessary number of bits to satisfy the FIPS 204 requirements. See the documentation on this library for more details which lists the default digest assigned based on the provided signature algorithm.
+
+**Parameters**:
+
+- *lib_ctx*: An openssl Library context. NULL is not valid. If this library context doesn't have the default provider loaded, it will be loaded into this context.
+- *sig_alg_name*: The required signature algorithm.
 
 **Returns**:
 A pointer to the newly created HASHMLDSA context on success, NULL on failure.

--- a/hashMLDSA.h
+++ b/hashMLDSA.h
@@ -19,8 +19,8 @@ limitations under the License.
 typedef struct hashMLDSA_ctx HASHMLDSA_CTX;
 typedef struct hashMLDSA HASHMLDSA;
 
-HASHMLDSA_CTX *HASHMLDSA_CTX_new(const char* sig_alg);
-HASHMLDSA_CTX *HASHMLDSA_CTX_new_for_test(const char* sig_alg);
+HASHMLDSA_CTX *HASHMLDSA_CTX_new(OSSL_LIB_CTX *lib_ctx, const char* sig_alg);
+HASHMLDSA_CTX *HASHMLDSA_CTX_new_for_test(OSSL_LIB_CTX *lib_ctx, const char* sig_alg);
 int HASHMLDSA_CTX_set_message_digest(HASHMLDSA_CTX *ctx, const char* digest_name, size_t hash_len);
 void HASHMLDSA_CTX_free(HASHMLDSA_CTX *ctx);
 

--- a/test_actions.c
+++ b/test_actions.c
@@ -29,6 +29,8 @@ typedef struct {
     EVP_PKEY *private_key;
 } Decoded_TestCase;
 
+static OSSL_LIB_CTX *lib_ctx;
+
 
 static int decode_testcase(TestCase test, Decoded_TestCase *decoded_testcase)
 {
@@ -85,9 +87,9 @@ typedef int (*create_context_and_data)(TestCase test, unsigned char det_mode, HA
 static int create_ctx_and_data(TestCase test, unsigned char det_mode, HASHMLDSA_CTX **hashmldsa_ctx, HASHMLDSA **hashmldsa_data, HASHMLDSA **hashmldsa_hash_data) {
     fprintf(stderr, "[INFO] using default hash on CONTEXT\n");
     if (det_mode == 'd')
-        *hashmldsa_ctx = HASHMLDSA_CTX_new_for_test(test.key_type);  /* this will create a deterministic signature */
+        *hashmldsa_ctx = HASHMLDSA_CTX_new_for_test(lib_ctx, test.key_type);  /* this will create a deterministic signature */
     else
-        *hashmldsa_ctx = HASHMLDSA_CTX_new(test.key_type);
+        *hashmldsa_ctx = HASHMLDSA_CTX_new(lib_ctx, test.key_type);
 
     if (*hashmldsa_ctx == NULL) {
         fprintf(stderr, "[ERROR] Failed to create new %s context\n", test.key_type);
@@ -135,9 +137,9 @@ error:
 static int create_ctx_with_hash_and_data(TestCase test, unsigned char det_mode, HASHMLDSA_CTX **hashmldsa_ctx, HASHMLDSA **hashmldsa_data, HASHMLDSA **hashmldsa_hash_data) {
     fprintf(stderr, "[INFO] Setting digest hash on CONTEXT to %s\n", test.hash_name);
     if (det_mode == 'd')
-        *hashmldsa_ctx = HASHMLDSA_CTX_new_for_test(test.key_type);  /* this will create a deterministic signature */
+        *hashmldsa_ctx = HASHMLDSA_CTX_new_for_test(lib_ctx, test.key_type);  /* this will create a deterministic signature */
     else
-        *hashmldsa_ctx = HASHMLDSA_CTX_new(test.key_type);
+        *hashmldsa_ctx = HASHMLDSA_CTX_new(lib_ctx, test.key_type);
 
     if (*hashmldsa_ctx == NULL) {
         fprintf(stderr, "[ERROR] Failed to create new %s context\n", test.key_type);
@@ -193,9 +195,9 @@ static int create_ctx_and_data_with_hash(TestCase test, unsigned char det_mode, 
     fprintf(stderr, "[INFO] setting hash on DATA to %s\n", test.hash_name);
 
     if (det_mode == 'd')
-        *hashmldsa_ctx = HASHMLDSA_CTX_new_for_test(test.key_type);  /* this will create a deterministic signature */
+        *hashmldsa_ctx = HASHMLDSA_CTX_new_for_test(lib_ctx, test.key_type);  /* this will create a deterministic signature */
     else
-        *hashmldsa_ctx = HASHMLDSA_CTX_new(test.key_type);
+        *hashmldsa_ctx = HASHMLDSA_CTX_new(lib_ctx, test.key_type);
 
     if (*hashmldsa_ctx == NULL) {
         fprintf(stderr, "[ERROR] Failed to create new %s context\n", test.key_type);
@@ -471,6 +473,8 @@ int main(int argc, char *argv[]) {
     create_context_and_data create_ctx_with_data;
     Decoded_TestCase decoded_testcase;
     TestCase test;
+
+    lib_ctx = OSSL_LIB_CTX_get0_global_default();
 
     numTestcases = sizeof(testcases) / sizeof(testcases[0]);
     printf("Number of testcases: %d\n", numTestcases);


### PR DESCRIPTION
This changes the API slightly but now the application needs to provide a library context. This library context must have the default provider loaded otherwise it isn't valid. A NULL library context is not valid either.